### PR TITLE
Fixed breaking build after `cargo update`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/kstep/rust-pocket.git"
 license = "MIT"
 
 [dependencies]
-hyper = "*"
-url = "*"
-rustc-serialize = "*"
-mime = "*"
-time = "*"
+hyper = "0.7.2"
+url = "0.5"
+rustc-serialize = "0.3"
+mime = "0.1"
+time = "0.1"
 
 [dev-dependencies]
-log = "*"
+log = "0.3.5"

--- a/README.md
+++ b/README.md
@@ -53,16 +53,20 @@ let added_item = pocket.push("http://example.com", Some("Example title"), Some("
 To query your pocket, use `Pocket::filter()` method:
 
 ```rust
-let items = pocket.filter()
-    .complete() // complete data
-    .archived() // archived items only
-    .videos()   // videos only
-    .offset(10) // items 10-20
-    .count(10)
-    .sort_by_title() // sorted by title
-    .get(); // get items
+let items = {
+    let mut f = pocket.filter();
+    
+    f.complete() // complete data
+    f.archived() // archived items only
+    f.videos()   // videos only
+    f.offset(10) // items 10-20
+    f.count(10)
+    f.sort_by_title() // sorted by title
+    f.get(); // get items
+};
 
 // There are other methods, see `PocketGetRequest` struct for details
+...
 ```
 
 The API bindings will be improved with new methods and parameters. Keep tuned!


### PR DESCRIPTION
At the moment `Cargo.toml` contains wildcards in versions of dependencies, which caused newer version of `mime` package to be pulled from **crates.io** and broke build with `hyper` 0.7.2.
